### PR TITLE
Add support for recording duration option and improve waiting mechanism

### DIFF
--- a/capjoy/src/nativeMain/kotlin/capjoy/Utils.kt
+++ b/capjoy/src/nativeMain/kotlin/capjoy/Utils.kt
@@ -21,12 +21,6 @@ fun createTempFile(
     return filePath
 }
 
-fun waitProcessing() {
-    println("Please press Enter to stop capturing process.")
-    readlnOrNull()
-    println("User input received.")
-}
-
 @OptIn(ExperimentalForeignApi::class)
 fun eprintln(message: String) {
     // print to stderr

--- a/capjoy/src/nativeMain/kotlin/capjoy/command/capture/CaptureAudioCommand.kt
+++ b/capjoy/src/nativeMain/kotlin/capjoy/command/capture/CaptureAudioCommand.kt
@@ -2,9 +2,12 @@ package capjoy.command.capture
 
 import capjoy.recorder.findDefaultDisplay
 import capjoy.recorder.startScreenRecord
-import capjoy.waitProcessing
+import capjoy.utils.DURATION_HELP
+import capjoy.utils.WAITING_HELP
+import capjoy.utils.waitProcessing
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.option
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.memScoped
 import platform.Foundation.NSRunLoop
@@ -14,8 +17,12 @@ import platform.ScreenCaptureKit.SCStreamConfiguration
 import platform.posix.exit
 
 @OptIn(ExperimentalForeignApi::class)
-class CaptureAudioCommand : CliktCommand("Capture audio from the screen") {
+class CaptureAudioCommand : CliktCommand(
+    "Capture audio from the screen",
+    epilog = WAITING_HELP,
+) {
     private val fileName: String by argument()
+    private val duration: String? by option(help = DURATION_HELP)
 
     override fun run() {
         memScoped {
@@ -36,7 +43,7 @@ class CaptureAudioCommand : CliktCommand("Capture audio from the screen") {
                     enableAudio = true,
                     captureConfiguration,
                 ) { screenRecorder ->
-                    waitProcessing()
+                    waitProcessing(duration)
 
                     screenRecorder.stop {
                         println("Writing finished: $fileName")

--- a/capjoy/src/nativeMain/kotlin/capjoy/command/capture/CaptureImageCommand.kt
+++ b/capjoy/src/nativeMain/kotlin/capjoy/command/capture/CaptureImageCommand.kt
@@ -29,6 +29,7 @@ import platform.ImageIO.CGImageDestinationFinalize
 class CaptureImageCommand : CliktCommand(
     "Capture an image of a window",
 ) {
+    // TODO support displayID
     private val windowID: Long by argument().long()
     private val path: String by argument()
     private val format by option().choice("png", "jpg")

--- a/capjoy/src/nativeMain/kotlin/capjoy/command/capture/CaptureMicCommand.kt
+++ b/capjoy/src/nativeMain/kotlin/capjoy/command/capture/CaptureMicCommand.kt
@@ -1,7 +1,9 @@
 package capjoy.command.capture
 
 import capjoy.recorder.startAudioRecording
-import capjoy.waitProcessing
+import capjoy.utils.DURATION_HELP
+import capjoy.utils.WAITING_HELP
+import capjoy.utils.waitProcessing
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.default
@@ -11,9 +13,13 @@ import platform.AVFoundation.AVFileType
 import platform.AVFoundation.AVFileTypeMPEG4
 import platform.AVFoundation.AVFileTypeWAVE
 
-class CaptureMicCommand : CliktCommand("Capture audio from the default input device") {
+class CaptureMicCommand : CliktCommand(
+    "Capture audio from the default input device",
+    epilog = WAITING_HELP,
+) {
     private val fileName: String by argument()
     private val format by option().choice("m4a", "wav").default("m4a")
+    private val duration: String? by option(help = DURATION_HELP)
 
     override fun run() {
         val outFormat: AVFileType? =
@@ -25,7 +31,7 @@ class CaptureMicCommand : CliktCommand("Capture audio from the default input dev
 
         val recorder = startAudioRecording(outFormat, fileName)
 
-        waitProcessing()
+        waitProcessing(duration)
 
         recorder.stop()
     }

--- a/capjoy/src/nativeMain/kotlin/capjoy/command/capture/CaptureMixCommand.kt
+++ b/capjoy/src/nativeMain/kotlin/capjoy/command/capture/CaptureMixCommand.kt
@@ -5,9 +5,12 @@ import capjoy.recorder.findDefaultDisplay
 import capjoy.recorder.mix
 import capjoy.recorder.startAudioRecording
 import capjoy.recorder.startScreenRecord
-import capjoy.waitProcessing
+import capjoy.utils.DURATION_HELP
+import capjoy.utils.WAITING_HELP
+import capjoy.utils.waitProcessing
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.option
 import platform.AVFoundation.AVFileTypeMPEG4
 import platform.Foundation.NSRunLoop
 import platform.Foundation.run
@@ -15,8 +18,12 @@ import platform.ScreenCaptureKit.SCContentFilter
 import platform.ScreenCaptureKit.SCStreamConfiguration
 import platform.posix.unlink
 
-class CaptureMixCommand : CliktCommand("Capture and mix mic audio and screen audio into a single file") {
+class CaptureMixCommand : CliktCommand(
+    "Capture and mix mic audio and screen audio into a single file",
+    epilog = WAITING_HELP,
+) {
     private val outFileName: String by argument()
+    private val duration: String? by option(help = DURATION_HELP)
 
     override fun run() {
         val micFile = createTempFile("capjoy-mix-mic-", ".m4a")
@@ -43,7 +50,7 @@ class CaptureMixCommand : CliktCommand("Capture and mix mic audio and screen aud
                 enableAudio = true,
                 captureConfiguration,
             ) { screenRecorder ->
-                waitProcessing()
+                waitProcessing(duration)
 
                 micRecorder.stop()
 

--- a/capjoy/src/nativeMain/kotlin/capjoy/command/capture/CaptureVideoCommand.kt
+++ b/capjoy/src/nativeMain/kotlin/capjoy/command/capture/CaptureVideoCommand.kt
@@ -2,7 +2,9 @@ package capjoy.command.capture
 
 import capjoy.recorder.findWindowByWindowId
 import capjoy.recorder.startScreenRecord
-import capjoy.waitProcessing
+import capjoy.utils.DURATION_HELP
+import capjoy.utils.WAITING_HELP
+import capjoy.utils.waitProcessing
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.default
@@ -24,11 +26,15 @@ import platform.ScreenCaptureKit.SCStreamConfiguration
 import platform.posix.exit
 
 @OptIn(ExperimentalForeignApi::class)
-class CaptureVideoCommand : CliktCommand("Capture video and audio from the screen") {
+class CaptureVideoCommand : CliktCommand(
+    "Capture video and audio from the screen",
+    epilog = WAITING_HELP,
+) {
     private val fileName: String by argument()
     private val showsCursor: Boolean by option().boolean().default(false)
     private val audio: Boolean by option().boolean().help("Enable audio recording").default(true)
     private val windowID: Long by argument().long()
+    private val duration: String? by option(help = DURATION_HELP)
 
     @OptIn(BetaInteropApi::class)
     override fun run() {
@@ -58,7 +64,7 @@ class CaptureVideoCommand : CliktCommand("Capture video and audio from the scree
                         enableAudio = audio,
                         captureConfiguration,
                     ) { screenRecorder ->
-                        waitProcessing()
+                        waitProcessing(duration)
 
                         screenRecorder.stop {
                             println("Writing finished: $fileName")

--- a/capjoy/src/nativeMain/kotlin/capjoy/utils/WaitProcessing.kt
+++ b/capjoy/src/nativeMain/kotlin/capjoy/utils/WaitProcessing.kt
@@ -14,7 +14,7 @@ fun waitProcessing(durationString: String?) {
         } catch (e: Exception) {
             error(
                 "Invalid duration format: $durationString\n" +
-                        "Supported format is: 10s, 1h 30m, 1h 30m 30s, etc."
+                    "Supported format is: 10s, 1h 30m, 1h 30m 30s, etc.",
             )
         }
         val seconds = duration.inWholeSeconds.toUInt()

--- a/capjoy/src/nativeMain/kotlin/capjoy/utils/WaitProcessing.kt
+++ b/capjoy/src/nativeMain/kotlin/capjoy/utils/WaitProcessing.kt
@@ -1,0 +1,29 @@
+package capjoy.utils
+
+import platform.posix.sleep
+import kotlin.time.Duration
+
+const val WAITING_HELP =
+    "Without the --duration option, the recording will continue until the Enter key is pressed."
+const val DURATION_HELP = "Recording duration(e.g. 10s, 1h 30)"
+
+fun waitProcessing(durationString: String?) {
+    if (durationString != null) {
+        val duration = try {
+            Duration.parse(durationString)
+        } catch (e: Exception) {
+            error(
+                "Invalid duration format: $durationString\n" +
+                        "Supported format is: 10s, 1h 30m, 1h 30m 30s, etc."
+            )
+        }
+        val seconds = duration.inWholeSeconds.toUInt()
+        println("Waiting for $seconds seconds...")
+        sleep(seconds)
+        println("Time's up!")
+    } else {
+        println("Please press Enter to stop capturing process.")
+        readlnOrNull()
+        println("User input received.")
+    }
+}


### PR DESCRIPTION
- Added --duration option to capture commands to specify recording duration.
- Modified `waitProcessing` function to handle both waiting for user input and duration-based waiting.
- Updated `CaptureAudioCommand`, `CaptureMicCommand`, `CaptureMixCommand`, and `CaptureVideoCommand` to use the new `waitProcessing` function.
- Moved `waitProcessing` to `capjoy.utils` and added constants for help messages.
- Updated command epilog to reflect new functionality.